### PR TITLE
use a sha1 hash for cachebusting instead of a random string

### DIFF
--- a/lib/sprite.js
+++ b/lib/sprite.js
@@ -12,13 +12,13 @@ var moduleRequire = require('./util/require');
 
 var engine, log;
 
-var getUrl = function (opt, name, ext) {
-  var cachebuster = !opt.cachebuster ? '' : '?' + crypto.randomBytes(20).toString('hex');
+var getUrl = function (opt, name, img) {
+  var cachebuster = !opt.cachebuster ? '' : '?' + crypto.createHash('sha1').update(img.contents).digest('hex');
   if (opt.cssPath.indexOf('//') > -1) {
-    return url.resolve(opt.cssPath, name + '.' + ext) + cachebuster;
+    return url.resolve(opt.cssPath, name + '.' + img.type) + cachebuster;
   }
   else {
-    return path.join(opt.cssPath, name + '.' + ext).replace(/\\/g, '/') + cachebuster;
+    return path.join(opt.cssPath, name + '.' + img.type).replace(/\\/g, '/') + cachebuster;
   }
 };
 
@@ -84,7 +84,7 @@ var createSprite = function (dim, layout, opt, base) {
     image = scaleSprite(base, dim.ratio, opt);
   }
   return image.then(function (img) {
-    var spriteUrl = getUrl(opt, name, img.type);
+    var spriteUrl = getUrl(opt, name, img);
     var baseDim = _.find(opt.dimension, {'default': true});
     if (opt.base64) {
       spriteUrl = 'data:' + img.mimeType + ';base64,' + img.contents.toString('base64');


### PR DESCRIPTION
Hey there,

I tweaked the cachebuster to use a sha1 hash of the sprite image instead of a random number, since I did not want to invalidate the cache in every run.

I really like your approach with sprity by the way. I'm currently migrating our projects from css-sprite and I'm very happy with it so far :-)