### PR TITLE
Eliminate global layout state.

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -6,8 +6,6 @@ var through2 = require('through2');
 var path = require('path');
 var Err = require('./util/error');
 
-var layouts;
-
 var getOrientation = function (opt) {
   if (opt.orientation === 'vertical') {
     return 'top-down';
@@ -41,12 +39,12 @@ var addTile = function (opt) {
     else {
       if (tile && tile.base && tile.width && tile.height) {
         var name = opt.split ? path.basename(tile.base) : 'default';
-        if (!layouts[name]) {
-          layouts[name] = layout(getOrientation(opt), {'sort': opt.sort});
+        if (!opt.layouts[name]) {
+          opt.layouts[name] = layout(getOrientation(opt), {'sort': opt.sort});
         }
         var height = tile.height + 2 * opt.margin;
         var width = tile.width + 2 * opt.margin;
-        layouts[name].addItem({
+        opt.layouts[name].addItem({
           height: height,
           width: width,
           meta: tile
@@ -60,12 +58,12 @@ var addTile = function (opt) {
 var pushLayouts = function (opt) {
   return function (cb) {
     var stream = this;
-    if (_.keys(layouts).length === 0) {
+    if (_.keys(opt.layouts).length === 0) {
       var e = new Err.LayoutError();
       stream.emit('error', e);
     }
     else {
-      _.each(layouts, function (l, key) {
+      _.each(opt.layouts, function (l, key) {
         stream.push({
           name: key,
           classname: getClassName(key, opt),
@@ -78,7 +76,6 @@ var pushLayouts = function (opt) {
 };
 
 module.exports = function (opt) {
-  layouts = {};
-
+  opt.layouts = {};
   return through2.obj(addTile(opt), pushLayouts(opt));
 };


### PR DESCRIPTION
Global state in this instance was preventing the ability for Sprity to process multiple PNG streams within the same invocation of node. The 'default' layout became a catchall for every PNG running through the stream.

My solution was to attach `layout` to the options object, which is unique to the stream and hidden from the user.