### PR TITLE
cachebuster: Use first 8 chars of SHA1 digest only

### DIFF
--- a/lib/sprite.js
+++ b/lib/sprite.js
@@ -13,7 +13,7 @@ var moduleRequire = require('./util/require');
 var engine, log;
 
 var getUrl = function (opt, name, img) {
-  var cachebuster = !opt.cachebuster ? '' : '?' + crypto.createHash('sha1').update(img.contents).digest('hex');
+  var cachebuster = !opt.cachebuster ? '' : '?' + crypto.createHash('sha1').update(img.contents).digest('hex').slice(0, 8);
   if (opt.cssPath.indexOf('//') > -1) {
     return url.resolve(opt.cssPath, name + '.' + img.type) + cachebuster;
   }


### PR DESCRIPTION
Instead of the full 40 characters, which seems fairly wasteful in production CSS.
It only has to be unique in the history of the same file, within cache age.
First 8 characters should provide more than enough entropy.
