### PR TITLE
adding default value on prefix documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ See [grunt-sprity](https://npmjs.org/package/grunt-sprity) for how to use `sprit
 * **margin**             margin in px between tiles  [*Default:* 4]
 * **opacity**            background opacity (0 - 100) of the sprite. defaults to 0 when png or 100 when jpg [*Default:* 0]
 * **orientation**        orientation of the sprite image (vertical|horizontal|binary-tree)  [*Default:* vertical]
-* **prefix**             prefix for the class name used in css (without .)
+* **prefix**             prefix for the class name used in css (without .) [*Default*: icon]
 * **no-sort**            disable sorting of layout. Read more about: [Layout algorithms](https://github.com/twolfson/layout#algorithms)
 * **split**              create sprite images for every sub folder [*Default:* false] [How to use split option](#how-to-use-split-option)
 * **style-indent-char**  Character used for indentation of styles (space|tab) [*Default:* space]


### PR DESCRIPTION
When looking at the generated sprite.scss file I took some time to find out where the **icon** class did appear (if it was config or because I was src'ing a folder named 'icon'), then found out it was from the default value of the prefix option. 
Just adding it to the readme to save time to new users :)
