### PR TITLE
Support node.js 6.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "optionalDependencies": {
     "sprity-css": "^1.0.2",
-    "sprity-lwip": "^1.0.3"
+    "sprity-lwip": "^1.0.6"
   },
   "devDependencies": {
     "chai": "^2.2.0",


### PR DESCRIPTION
When I compile with node 6.3.0 I get compilation error:

```
/var/project
> └─┬ lwip@0.0.9 
>   ├── async@2.0.1 
>   ├── bindings@1.2.1 
>   └─┬ decree@0.0.6 
>     └── lodash-node@2.4.1 
> 
> npm WARN optional Skipping failed optional dependency /chokidar/fsevents:
> npm WARN notsup Not compatible with your operat
> 
> exit
> ^C
root@instance-3:/var/task-money/gpt_frontend# 
root@instance-3:/var/task-money/gpt_frontend# npm i sprity
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

> lwip@0.0.8 install /var/task-money/gpt_frontend/node_modules/sprity-lwip/node_modules/lwip
> node-gyp rebuild

make: Entering directory `/var/task-money/gpt_frontend/node_modules/sprity-lwip/node_modules/lwip/build'
  CXX(target) Release/obj.target/lwip_decoder/src/decoder/init.o
In file included from ../src/decoder/decoder.h:13:0,
                 from ../src/decoder/init.cpp:1:
../../nan/nan.h:590:20: error: variable or field ‘AddGCEpilogueCallback’ declared void
       v8::Isolate::GCEpilogueCallback callback
                    ^
../../nan/nan.h:590:7: error: ‘GCEpilogueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCEpilogueCallback callback
       ^
../../nan/nan.h:591:18: error: expected primary-expression before ‘gc_type_filter’
     , v8::GCType gc_type_filter = v8::kGCTypeAll) {
                  ^
../../nan/nan.h:596:20: error: variable or field ‘RemoveGCEpilogueCallback’ declared void
       v8::Isolate::GCEpilogueCallback callback) {
                    ^
../../nan/nan.h:596:7: error: ‘GCEpilogueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCEpilogueCallback callback) {
       ^
../../nan/nan.h:601:20: error: variable or field ‘AddGCPrologueCallback’ declared void
       v8::Isolate::GCPrologueCallback callback
                    ^
../../nan/nan.h:601:7: error: ‘GCPrologueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCPrologueCallback callback
       ^
../../nan/nan.h:602:18: error: expected primary-expression before ‘gc_type_filter’
     , v8::GCType gc_type_filter = v8::kGCTypeAll) {
                  ^
../../nan/nan.h:607:20: error: variable or field ‘RemoveGCPrologueCallback’ declared void
       v8::Isolate::GCPrologueCallback callback) {
                    ^
../../nan/nan.h:607:7: error: ‘GCPrologueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCPrologueCallback callback) {
       ^
make: *** [Release/obj.target/lwip_decoder/src/decoder/init.o] Error 1
make: Leaving directory `/var/task-money/gpt_frontend/node_modules/sprity-lwip/node_modules/lwip/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:204:12)
gyp ERR! System Linux 3.19.0-66-generic
gyp ERR! command "/usr/bin/nodejs" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /var/project/node_modules/sprity-lwip/node_modules/lwip
gyp ERR! node -v v6.3.0
gyp ERR! node-gyp -v v3.3.1
gyp ERR! not ok 
npm WARN install:lwip@0.0.8 lwip@0.0.8 install: `node-gyp rebuild`
npm WARN install:lwip@0.0.8 Exit status 1
```

We need to update sprity-lwip up to 1.0.6
