### PR TITLE
use stable (natural) sort order for input files

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var vfs = require('vinyl-fs');
 var ifStream = require('ternary-stream');
 var through2 = require('through2').obj;
+var naturalSort = require('gulp-natural-sort');
 
 var tile = require('./lib/tile');
 var layout = require('./lib/layout');
@@ -92,6 +93,7 @@ module.exports = {
     };
 
     var stream = vfs.src(opts.src)
+      .pipe(naturalSort())
       .pipe(tile(opts))
       .on('error', handleError())
       .pipe(layout(opts))

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "colors": "^1.0.3",
     "cssesc": "^0.1.0",
     "fs-extra": "^0.18.2",
+    "gulp-natural-sort": "^0.1.1",
     "handlebars": "^3.0.2",
     "imageinfo": "^1.0.4",
     "layout": "~2.2.0",


### PR DESCRIPTION
This pull request makes sure that the sprites are sorted according to the natural order of their filenames. Requires that sprity is run with the `--no-sort` flag.